### PR TITLE
Use `gsutil rsync` rather than manually `rm`-ing and `cp`-ing

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -62,5 +62,4 @@ tasks:
       export GOOGLE_APPLICATION_CREDENTIALS=~/gcp-credentials.json
       echo "$GCP_CREDENTIALS" > "$GOOGLE_APPLICATION_CREDENTIALS"
       gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-      gsutil -m rm -r gs://www.gigamesh.io/* || true
-      gsutil -m cp -r dist/* gs://www.gigamesh.io
+      gsutil -m rsync -d -r -c dist gs://www.gigamesh.io


### PR DESCRIPTION
Use `gsutil rsync` rather than manually `rm`-ing and `cp`-ing.