### PR TITLE
Enable the `esModuleInterop` option for the TypeScript compiler

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-unresolved, no-unused-vars
 import { Request, Response } from "express";
 
-import * as sendgrid from "@sendgrid/mail";
+import sendgrid from "@sendgrid/mail";
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 import { isProduction } from "./environment";
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "CommonJS",
     "moduleResolution": "node",
     "outDir": "dist",
     "strict": true,
-    "target": "ES2018",
-    "module": "CommonJS"
+    "target": "ES2018"
   },
   "files": ["src/index.ts"]
 }

--- a/frontend/src/script/main.tsx
+++ b/frontend/src/script/main.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
-import * as React from "react";
+import React from "react";
 
-import * as ReactDOM from "react-dom";
+import ReactDOM from "react-dom";
 import { helloWorld } from "./endpoints";
 
 // eslint-disable-next-line no-unused-vars

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
+    "jsx": "react",
     "moduleResolution": "node",
     "strict": true,
-    "target": "ES6",
-    "jsx": "react"
+    "target": "ES6"
   },
   "files": ["src/script/main.tsx"]
 }


### PR DESCRIPTION
Enable the `esModuleInterop` option for the TypeScript compiler.