### PR TITLE
Set `overscroll-behavior` to keep the header from bounding

### DIFF
--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -32,6 +32,7 @@ html {
     width: 100%;
     min-width: $min-width;
     height: 100%;
+    overscroll-behavior: none; // This doesn't work in Safari, unfortunately.
   }
 
   // Style the body and its contents.


### PR DESCRIPTION
Set `overscroll-behavior` to keep the header from bounding.