### PR TITLE
Make the DOM structure more straightforward

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -37,7 +37,7 @@
     <script src="/vendor/google-analytics.js"></script>
   </head>
   <body>
-    <div id="main"></div>
+    <div id="react-root"></div>
     <script src="/script/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/script/main.tsx
+++ b/frontend/src/script/main.tsx
@@ -172,7 +172,7 @@ class Main extends React.Component<{}, { authenticationFormVisible: boolean }> {
 }
 
 // Render the main component.
-ReactDOM.render(<Main />, document.getElementById("main"));
+ReactDOM.render(<Main />, document.getElementById("react-root"));
 
 // FastClick eliminates the 300ms delay between a physical tap and the firing of a click event on
 // mobile browsers.


### PR DESCRIPTION
Make the DOM structure more straightforward. Previously we had this structure:

```html
<div id="main">
  <div class="main">
    ...
  </div>
</div>
```

Seeing `main` twice in the DOM is confusing, so this PR changes it to:

```html
<div id="react-root">
  <div class="main">
    ...
  </div>
</div>
```

Note that both of these `div`s are required. The outer one is the React root, and the inner one comes from the top-level React component (which comes from the JSX).