### PR TITLE
Rename `react-root` to `root`

### DIFF
--- a/frontend/src/index/index.html
+++ b/frontend/src/index/index.html
@@ -5,6 +5,6 @@
     <title>Webpack Scaffolding</title>
   </head>
   <body>
-    <div id="react-root"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/frontend/src/index/index.tsx
+++ b/frontend/src/index/index.tsx
@@ -7,5 +7,5 @@ ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('react-root'),
+  document.getElementById('root'),
 );


### PR DESCRIPTION
Rename `react-root` to `root`. Just personal preference.