### PR TITLE
For production, strip (incomplete) license info and don't generate source maps

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -58,13 +58,16 @@ module.exports = {
     }),
   ],
   optimization: {
-    minimizer: [new TerserJSPlugin({})],
+    minimizer: [
+      new TerserJSPlugin({
+        extractComments: false,
+      }),
+    ],
   },
   output: {
     filename: '[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
   },
-  devtool: 'source-map',
   devServer: {
     contentBase: './dist',
   },

--- a/frontend/webpack.development.js
+++ b/frontend/webpack.development.js
@@ -4,7 +4,7 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
-// Enable source maps. We disable source maps in production because
+// Enable source maps for styles. We disable source maps in production because
 // `style-loader` only supports inline source maps, which lead to bloat.
 // However, that bloat is not as much of a concern in development.
 const cssLoader = common.module.rules[1].use[1];
@@ -28,5 +28,9 @@ if (styleLoader.loader === 'style-loader') {
 }
 
 module.exports = merge(common, {
+  // Development mode
   mode: 'development',
+
+  // Enable source maps for scripts.
+  devtool: 'source-map',
 });

--- a/frontend/webpack.production.js
+++ b/frontend/webpack.production.js
@@ -3,5 +3,6 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
+  // Production mode
   mode: 'production',
 });


### PR DESCRIPTION
For production, strip (incomplete) license info and don't generate source maps.