### PR TITLE
Remove a workaround for a bug in `gcloud`

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -239,9 +239,7 @@ tasks:
       echo "$GCP_CREDENTIALS" > "$GOOGLE_APPLICATION_CREDENTIALS"
       gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 
-      # Deploy the Cloud Functions. We copy the code into a new directory because `gcloud` doesn't
-      # seem to like the fact that the files are owned by `root` (even though `user` can read from
-      # and write to them).
+      # Deploy the Cloud Functions.
       cp -LR backend /tmp/backend
       gcloud functions deploy api \
         --project "$GCP_PROJECT_ID" \


### PR DESCRIPTION
I got a job at Google and fixed the bug, so now I can remove this workaround.

The bug was that `gcloud functions deploy ...` would fail if all of the following were true:

1. The user is deploying files from a local filesystem (as opposed to a Google Cloud Storage bucket).
2. At least one of the files being deployed is not writable by the user (e.g., because it is owned by root).
3. One of the non-writable files has an `mtime` older than 1980 (e.g., midnight on 1970-01-01).

That seems like an unlikely combination of factors, but it's fairly common when using [Toast](https://github.com/stepchowfun/toast), which copies files into a Docker container as root without preserving `mtime`s.