### PR TITLE
Remove `morgan` request logging

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1762,15 +1762,6 @@
       "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
       "dev": true
     },
-    "@types/morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-2j5IKrgJpEP6xw/uiVb2Xfga0W0sSVD9JP9t7EZLvpBENdB0OKgcnoKS8IsjNeNnZ/86robdZ61Orl0QCFGOXg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "14.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
@@ -2490,14 +2481,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-    },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -7721,25 +7704,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-      "requires": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -8067,11 +8031,6 @@
       "requires": {
         "ee-first": "1.1.1"
       }
-    },
-    "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@types/express": "^4.17.1",
     "@types/jest": "^26.0.10",
-    "@types/morgan": "^1.9.1",
     "@types/pg": "^7.14.5",
     "@types/winston": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
@@ -36,7 +35,6 @@
     "@google-cloud/secret-manager": "^3.2.0",
     "@sendgrid/mail": "^7.2.0",
     "express": "^4.17.1",
-    "morgan": "^1.10.0",
     "pg": "^8.4.1",
     "runtypes": "^5.0.1",
     "winston": "^3.3.3"

--- a/backend/src/entry/entry.ts
+++ b/backend/src/entry/entry.ts
@@ -1,5 +1,4 @@
 import express, { Request, Response } from 'express';
-import morgan from 'morgan';
 import { Static } from 'runtypes';
 import emailDemo from '../api/emailDemo';
 import logger from '../logger/logger';
@@ -20,6 +19,8 @@ async function handleRpc(request: Request, response: Response): Promise<void> {
   const payload = request.body;
 
   if (ApiRequest.guard(payload)) {
+    logger.info('Received valid request.', { request: payload });
+
     const apiResponse = await ApiRequest.match<
       Promise<Static<typeof ApiResponse>>
     >(
@@ -35,6 +36,7 @@ async function handleRpc(request: Request, response: Response): Promise<void> {
 
     response.status(200).send(apiResponse);
   } else {
+    logger.info('Bad request.', { request: payload });
     response.status(400).send('Bad Request');
   }
 }
@@ -59,9 +61,6 @@ const app = express();
 // Populate the `body` field of incoming requests.
 app.use(express.json());
 
-// Log requests.
-app.use(morgan('tiny'));
-
 // Disable the `x-powered-by` header.
 app.disable('x-powered-by');
 
@@ -73,5 +72,5 @@ app.options('/', handleOptions);
 // Start the server.
 app.listen(port, () => {
   // The server has started.
-  logger.info('Listening on port %s…', port);
+  logger.info('Server started.', { port });
 });

--- a/backend/src/logger/logger.ts
+++ b/backend/src/logger/logger.ts
@@ -2,14 +2,7 @@ import { createLogger, format, transports } from 'winston';
 
 const logger = createLogger({
   level: 'info',
-  format: format.combine(
-    format.timestamp({
-      format: 'YYYY-MM-DD HH:mm:ss',
-    }),
-    format.errors({ stack: true }),
-    format.splat(),
-    format.json(),
-  ),
+  format: format.combine(format.timestamp(), format.json()),
   transports: [new transports.Console()],
 });
 


### PR DESCRIPTION
Remove `morgan` request logging. Google Cloud Run already logs requests. Note that we're using a different logging package (`winston`) for more ad hoc logging.

**Status:** Ready

**Fixes:** N/A
