### PR TITLE
Remove the database name from the connection string in the installation instructions, since the database hasn't been created at that point

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -68,7 +68,7 @@
         - Connect to the database using a command like the following:
 
           ```sh
-          psql 'sslmode=verify-ca sslrootcert=server-ca.pem sslcert=client-cert.pem sslkey=client-key.pem hostaddr=35.223.233.124 port=5432 user=postgres dbname=gigamesh'
+          psql 'sslmode=verify-ca sslrootcert=server-ca.pem sslcert=client-cert.pem sslkey=client-key.pem hostaddr=35.223.233.124 port=5432 user=postgres'
           ```
         - Log in using the password you created for the `postgres` user above.
         - Enter the following:


### PR DESCRIPTION
Remove the database name from the connection string in the installation instructions, since the database hasn't been created at that point.

**Status:** Ready

**Fixes:** N/A
