### PR TITLE
Create a more restricted database user

### DIFF
--- a/shared/src/constants/constants.ts
+++ b/shared/src/constants/constants.ts
@@ -8,17 +8,17 @@ export const originProduction = 'https://www.gigamesh.io';
 
 // This constant points to the secrets in GCP Secret Manager.
 export const postgresSecretName =
-  'projects/gigamesh-293109/secrets/postgres/versions/latest';
+  'projects/gigamesh-293109/secrets/postgres-api/versions/latest';
 export const sendgridSecretName =
   'projects/gigamesh-293109/secrets/sendgrid/versions/latest';
 
 // These constants are used for connecting to the database.
-export const databaseUserDevelopment = 'postgres';
+export const databaseUserDevelopment = 'api';
 export const databaseNameDevelopment = 'gigamesh';
 export const databaseHostDevelopment = '127.0.0.1';
 export const databasePortDevelopment = 5432;
 export const databaseNameProduction = 'gigamesh';
-export const databaseUserProduction = 'postgres';
+export const databaseUserProduction = 'api';
 export const databaseHostProduction =
   '/cloudsql/gigamesh-293109:us-central1:gigamesh';
 export const databasePortProduction = undefined;


### PR DESCRIPTION
Create a more restricted database user for the API service. We're going to try something innovative with this user: it will have append-only access to the database. A separate service/job can be used to do garbage collection, compaction, and any other activities that require mutation.

**Status:** Ready

**Fixes:** N/A
