### PR TITLE
Use a new naming convention for fingerprinted files

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -17,11 +17,9 @@ module.exports = {
       {
         test: /\.(ts|tsx)$/,
         exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            configFile: path.resolve(__dirname, 'babel.config.json'),
-          },
+        loader: 'babel-loader',
+        options: {
+          configFile: path.resolve(__dirname, 'babel.config.json'),
         },
       },
       {
@@ -55,7 +53,10 @@ module.exports = {
       },
       {
         test: /\.svg$/,
-        use: ['file-loader'],
+        loader: 'file-loader',
+        options: {
+          name: '[contenthash]-fingerprint.[ext]',
+        },
       },
     ],
   },
@@ -81,7 +82,7 @@ module.exports = {
     ],
   },
   output: {
-    filename: '[contenthash].js',
+    filename: '[contenthash]-fingerprint.js',
     path: path.resolve(__dirname, 'dist'),
   },
   devServer: {

--- a/frontend/webpack.development.js
+++ b/frontend/webpack.development.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');

--- a/toast.yml
+++ b/toast.yml
@@ -379,9 +379,6 @@ tasks:
       #        [ref:file_discoverability], the fingerprinted files will not be
       #        requested by clients while the first deploy is in progress.
 
-      # Files with these extensions are fingerprinted.
-      FINGERPRINTED_EXTENSIONS='js svg'
-
       # Authenticate with the Google Cloud SDK.
       GOOGLE_KEY_FILE=~/gcp-credentials.json
       echo "$GCP_DEPLOY_CREDENTIALS" > "$GOOGLE_KEY_FILE"
@@ -399,20 +396,16 @@ tasks:
         "gs://$STAGING_BUCKET/dist/*"
 
       # Allow fingerprinted files to be cached for up to a week.
-      for EXTENSION in $FINGERPRINTED_EXTENSIONS; do
-        gsutil -m setmeta \
-          -h 'Cache-Control:public, max-age=604800, immutable' \
-          "gs://$STAGING_BUCKET/dist/*.$EXTENSION"
-      done
+      gsutil -m setmeta \
+        -h 'Cache-Control:public, max-age=604800, immutable' \
+        "gs://$STAGING_BUCKET/dist/*-fingerprint.*"
 
       # Copy the fingerprinted files to the production bucket. It's important
       # to copy the fingerprinted files before copying the non-fingerprinted
       # files due to [ref:deploy_fingerprinted_files_first].
-      for EXTENSION in $FINGERPRINTED_EXTENSIONS; do
-        gsutil -m cp \
-          "gs://$STAGING_BUCKET/dist/*.$EXTENSION" \
-          "gs://$PRODUCTION_BUCKET"
-      done
+      gsutil -m cp \
+        "gs://$STAGING_BUCKET/dist/*-fingerprint.*" \
+        "gs://$PRODUCTION_BUCKET"
 
       # Copy the remaining files to the production bucket.
       gsutil -m cp "gs://$STAGING_BUCKET/dist/*" "gs://$PRODUCTION_BUCKET"


### PR DESCRIPTION
Use a new naming convention for fingerprinted files. This allows us to simplify our deploy script.

**Status:** Ready

**Fixes:** N/A
