### PR TITLE
Minimize the number of operations we do in transactions

### DIFF
--- a/backend/src/session/session.test.ts
+++ b/backend/src/session/session.test.ts
@@ -1,0 +1,3 @@
+describe('session', () => {
+  it.todo('works');
+});

--- a/backend/src/session/session.ts
+++ b/backend/src/session/session.ts
@@ -1,0 +1,55 @@
+import { Pool, PoolClient } from 'pg';
+
+import { getPool } from '../storage/storage';
+import {
+  sessionLifespanSinceActiveMs,
+  sessionLifespanSinceCreationMs,
+} from '../constants/constants';
+
+export default async function validateSession(
+  sessionId: string,
+  connection?: Pool | PoolClient,
+): Promise<string | null> {
+  // Make sure we have a client.
+  let clientOrPool = connection;
+  if (clientOrPool === undefined) {
+    clientOrPool = await getPool();
+  }
+
+  // Fetch the session.
+  const sessions = (
+    await clientOrPool.query<{
+      createdAt: Date;
+      refreshedAt: Date;
+      userId: string;
+    }>(
+      'SELECT created_at AS "createdAt", refreshed_at AS "refreshedAt", user_id AS "userId" ' +
+        'FROM session ' +
+        'WHERE id = $1 ' +
+        'LIMIT 1',
+      [sessionId],
+    )
+  ).rows;
+  if (sessions.length === 0) {
+    return null;
+  }
+  const session = sessions[0];
+
+  // Make sure the session hasn't expired.
+  if (
+    session.createdAt.valueOf() + sessionLifespanSinceCreationMs <=
+      Date.now() ||
+    session.refreshedAt.valueOf() + sessionLifespanSinceActiveMs <= Date.now()
+  ) {
+    return null;
+  }
+
+  // Refresh the session.
+  await clientOrPool.query<{}>(
+    'UPDATE session SET refreshed_at = now() WHERE id = $1',
+    [sessionId],
+  );
+
+  // If we made it this far, the session is legitimate. Return the user ID.
+  return session.userId;
+}

--- a/backend/src/storage/storage.ts
+++ b/backend/src/storage/storage.ts
@@ -1,10 +1,6 @@
-import { Client, Pool } from 'pg';
+import { Pool } from 'pg';
 
-import {
-  databaseConnectionInfo,
-  sessionLifespanSinceActiveMs,
-  sessionLifespanSinceCreationMs,
-} from '../constants/constants';
+import { databaseConnectionInfo } from '../constants/constants';
 import { getPostgresSecret } from '../secrets/secrets';
 
 let pool: Pool | null = null;
@@ -22,52 +18,4 @@ export async function getPool(): Promise<Pool> {
   }
 
   return pool;
-}
-
-export async function sessionIdToUserId(
-  sessionId: string,
-  connection?: Client | Pool,
-): Promise<string | null> {
-  // Make sure we have a client.
-  let clientOrPool = connection;
-  if (clientOrPool === undefined) {
-    clientOrPool = await getPool();
-  }
-
-  // Fetch the session.
-  const sessions = (
-    await clientOrPool.query<{
-      createdAt: Date;
-      refreshedAt: Date;
-      userId: string;
-    }>(
-      'SELECT created_at AS "createdAt", refreshed_at AS "refreshedAt", user_id AS "userId" ' +
-        'FROM session ' +
-        'WHERE id = $1 ' +
-        'LIMIT 1',
-      [sessionId],
-    )
-  ).rows;
-  if (sessions.length === 0) {
-    return null;
-  }
-  const session = sessions[0];
-
-  // Make sure the session hasn't expired.
-  if (
-    session.createdAt.valueOf() + sessionLifespanSinceCreationMs <=
-      Date.now() ||
-    session.refreshedAt.valueOf() + sessionLifespanSinceActiveMs <= Date.now()
-  ) {
-    return null;
-  }
-
-  // Refresh the session.
-  await clientOrPool.query<{}>(
-    'UPDATE session SET refreshed_at = now() WHERE id = $1',
-    [sessionId],
-  );
-
-  // If we made it this far, the session is legitimate. Return the user ID.
-  return session.userId;
 }


### PR DESCRIPTION
Minimize the number of operations we do in transactions.

The main motivation for this change isn't performance. It's to make it clear what operations need to happen atomically to maintain data integrity. Generally speaking, we prefer to use database constraints over transactions for ensuring data integrity. Sometimes, however, that is not possible or practical.

**Status:** Ready

**Fixes:** N/A
