### PR TITLE
Lock rows when necessary to ensure data integrity

### DIFF
--- a/backend/src/api/changeEmail.ts
+++ b/backend/src/api/changeEmail.ts
@@ -72,7 +72,8 @@ export default async function changeEmail(
           'SELECT id, email, normalized_email as "normalizedEmail" ' +
             'FROM "user" ' +
             'WHERE id = $1 ' +
-            'LIMIT 1',
+            'LIMIT 1 ' +
+            'FOR UPDATE',
           [userId],
         )
       ).rows[0];

--- a/backend/src/api/logOut.ts
+++ b/backend/src/api/logOut.ts
@@ -10,7 +10,7 @@ export default async function logOut(
   const pool = await getPool();
 
   // Delete the session if it exists.
-  await pool.query<{}>('DELETE FROM session WHERE id = $1 ', [
+  await pool.query<{}>('DELETE FROM session WHERE id = $1', [
     payload.sessionId,
   ]);
 


### PR DESCRIPTION
Lock rows when necessary to ensure data integrity.

Alternatively, we could switch the database to use a stronger isolation level. But this way we can keep the performance of read committed (for now at least).

**Status:** Ready

**Fixes:** N/A
