### PR TITLE
Default to `public` in the `Cache-Control` header for the HTML (for SEO purposes)

### DIFF
--- a/backend/src/main.tsx
+++ b/backend/src/main.tsx
@@ -111,7 +111,7 @@ function handleRoot(request: Request, response: Response): void {
   response
     .status(200)
     .set('Content-Type', 'text/html')
-    .set('Cache-Control', 'max-age=0, must-revalidate, private')
+    .set('Cache-Control', 'public, max-age=0, must-revalidate')
     .write(htmlPrefix);
 
   const sheet = new ServerStyleSheet();


### PR DESCRIPTION
Default to `public` in the `Cache-Control` header for the HTML (for SEO purposes).

**Status:** Ready

**Fixes:** N/A
