### PR TITLE
Disable (weak) etag generation for static files since (a) we set a generous max-age and (b) I don't trust timestamp-based etags

### DIFF
--- a/backend/src/main.tsx
+++ b/backend/src/main.tsx
@@ -139,6 +139,7 @@ app.use(express.json());
 // Serve static files.
 app.use(
   express.static('static', {
+    etag: false,
     index: false,
     lastModified: false,
     setHeaders: (response, path) => {


### PR DESCRIPTION
Disable (weak) etag generation for static files since (a) we set a generous max-age and (b) I don't trust timestamp-based etags.

**Status:** Ready

**Fixes:** N/A
