### PR TITLE
Set the canonical URL as a response header because the non-canonical Google Cloud Run URL cannot be disabled

### DIFF
--- a/backend/src/api/endpoints/invite/invite.ts
+++ b/backend/src/api/endpoints/invite/invite.ts
@@ -39,7 +39,7 @@ export default async function invite(
     ).rows[0].id;
 
     // Construct the signup link.
-    const signupLink = `${origin()}${signUpWebRoute(signupProposalId)}`;
+    const signupLink = `${origin}${signUpWebRoute(signupProposalId)}`;
 
     // Send the proposal to the user.
     await send({
@@ -63,7 +63,7 @@ export default async function invite(
     ).rows[0].id;
 
     // Construct the login link.
-    const logInLink = `${origin()}${logInWebRoute(loginProposalId)}`;
+    const logInLink = `${origin}${logInWebRoute(loginProposalId)}`;
 
     // Send the proposal to the user.
     await send({

--- a/backend/src/constants/constants.ts
+++ b/backend/src/constants/constants.ts
@@ -6,14 +6,11 @@ const gcpRegion = 'us-central1';
 // in production than in development/test.
 export const isProduction = process.env.NODE_ENV === 'production';
 
-// This is used to generate links in emails.
-export function origin(): string {
-  if (isProduction) {
-    return 'https://www.gigamesh.io';
-  }
-
-  return 'http://localhost:8080';
-}
+// This is used to generate links in emails and to add canonical URLs to HTTP
+// responses.
+export const origin = isProduction
+  ? 'https://www.gigamesh.io'
+  : 'http://localhost:8080';
 
 // This constant points to the secrets in GCP Secret Manager.
 export const postgresSecretName = `projects/${gcpProjectId}/secrets/postgres-production/versions/latest`;

--- a/backend/src/main/main.ts
+++ b/backend/src/main/main.ts
@@ -8,7 +8,7 @@ import { randomBytes } from 'crypto';
 import installRoutes from '../routes/routes';
 import logger from '../logger/logger';
 import renderPage from '../page/page';
-import { isProduction } from '../constants/constants';
+import { isProduction, origin } from '../constants/constants';
 
 // Read the `HOST` environment variable.
 const hostRaw = process.env.HOST;
@@ -59,6 +59,12 @@ app.use(express.json());
 
 // Populate the `cookies` field of incoming requests.
 app.use(cookieParser());
+
+// Set the canonical URL as a response header.
+app.use((request: Request, response: Response, next: NextFunction) => {
+  response.set({ Link: `<${origin}${request.url}>; rel="canonical"` });
+  next();
+});
 
 // Serve static files.
 app.use(


### PR DESCRIPTION
Set the canonical URL as a response header because the non-canonical Google Cloud Run URL cannot be disabled.

**Status:** Ready

**Fixes:** N/A
