### PR TITLE
Update the MAINTAINERS instructions regarding secrets in GitHub

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -630,7 +630,8 @@
     the `main` branch. Follow the steps below to make this work.
     - Create a new Docker repository on [Docker Hub](https://hub.docker.com/).
       You'll need to create a Docker ID if you don't already have one.
-    - Set up two secrets in the repository settings on GitHub.
+    - Set up two secrets in the repository settings on GitHub as described in
+      [MAINTAINERS.md](https://github.com/stepchowfun/gigamesh/blob/main/MAINTAINERS.md).
       - `DOCKER_PASSWORD`: This is your Docker ID password. Toast will use it to
         cache intermediate Docker images when performing builds.
       - `GCP_DEPLOY_CREDENTIALS`: This should contain the contents of the

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,9 @@ and users need not be concerned with this material.
 
 When setting up the repository on GitHub, configure the following settings:
 
-- Under `Secrets`, add the repository secrets described in `INSTALLATION.md`.
+- Under `Secrets`:
+  - Under `Actions`, add the repository secrets described in `INSTALLATION.md`.
+  - Add the same repository secrets under `Dependabot`.
 - Under `Branches`, add a branch protection rule for the `main` branch.
   - Enable `Require status checks to pass before merging`.
     - Enable `Require branches to be up to date before merging`.


### PR DESCRIPTION
Update the `MAINTAINERS` instructions regarding secrets in GitHub.

**Status:** Ready

**Fixes:** N/A